### PR TITLE
Fixed bug in delete_tag

### DIFF
--- a/js/typeahead.tagging.js
+++ b/js/typeahead.tagging.js
@@ -104,7 +104,7 @@
         // removes a tag and updates the hidden input
         var removed_tag = $tagging_tag.clone().children().remove().end().text()
           , tag_index = $.tagging.current_taglist.indexOf(removed_tag);
-        $.tagging.current_taglist.pop(tag_index);
+        $.tagging.current_taglist.splice(tag_index,1);
         $tagging_tag.remove();
 
         sync_input();


### PR DESCRIPTION
delete_tag() was using pop() to remove a specific element in the current_taglist array. That resulted in the first item in the list always being removed, regardless of which tag was clicked. Changed pop() to splice() to correct issue.
